### PR TITLE
Add posters from abstract search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This contains materials related to tedana and multi-echo fMRI presented at the O
 This is a place to centralize multi-echo related content at OHBM 2024. If you see or have a poster or presentation using multi-echo fMRI, submit a pull request or [comment on issue #1](https://github.com/ME-ICA/ohbm-2024-multiecho/issues/1) to have it added.
 
 ## Multi-echo presentations
+- Longitudinal iron in caudate related to control network connectivity and planning in older adults
+- Multimodal precision neuroimaging of the individual human brain at ultra-high field
+
+Both in Neuroscience Frontiers: Exploring Cognitive Dynamics and Brain Connectivity
+Monday, June 24, 2024: 5:45 PM - 7:00 PM
 
 ## Multi-echo posters
 
@@ -58,10 +63,3 @@ Poster WedThur 1336
 - 2408: Individualised mapping of the language system using ultra high-field fMRI
 - 2410: Longitudinal iron in caudate related to control network connectivity and planning in older adults
 - 2453: Adults born via C-section have visual attention deficits and aberrant brain network connectivity
-
-## Presentations
-- Longitudinal iron in caudate related to control network connectivity and planning in older adults
-- Multimodal precision neuroimaging of the individual human brain at ultra-high field
-
-Both in Neuroscience Frontiers: Exploring Cognitive Dynamics and Brain Connectivity
-Monday, June 24, 2024: 5:45 PM - 7:00 PM

--- a/README.md
+++ b/README.md
@@ -12,4 +12,56 @@ This is a place to centralize multi-echo related content at OHBM 2024. If you se
 
 **Tedana Community**: Peter A. Bandettini, Logan Dowdle, Elizabeth DuPre, Javier Gonzalez-Castillo, Daniel Handwerker, Christopher Markiewicz, Stefano Moia, Peter Molfese, Neha Reddy, Taylor Salo, Joshua Teves, Eneko Uruñuela
 
-Poster WedThurs 1336
+Poster WedThur 1336
+
+### Posters with a focus on multi-echo fMRI
+### MonTue posters
+- 1286: High field multi-echo fMRI in infants
+
+## WedThur posters
+- 1355: Activation analysis of T2* time-series from multi-echo fMRI data
+- 1698: Hydra Nordic: A thermal-noise removal strategy for multi-echo fMRI
+- 1877: Accelerating multi-echo brain MRI at 7T using variable-density sampling & patch-based regularization
+- 1979: Evaluation of QSM Reconstruction Pipelines for Multi-echo Gradient-echo Acquisitions
+- 2267: Containerized pipeline for handling multi-echo fMRI data
+- 2317: Precision individual difference with multi-echo functional MRI
+- 2325: Enhancing White Matter fMRI Reliability through BOLD-like Signals Using Multi-Echo Techniques
+- 2500: Improved performance of within- and between-individual pain prediction using multi-echo fMRI
+
+### Posters using multi-echo fMRI
+## MonTue posters
+- 117: A comprehensive approach for TMS targeting identifies better targets than typical approaches
+- 127: TMS direct effects of orbitofrontal cortex stimulation: An interleaved TMS-fMRI study
+- 301: Essential Tremor: The Relationship Between Hand Dominance and Tremor Severity by MVPA
+- 441: Brain dynamics in toddlers with and without autism spectrum disorder
+- 466: Connectivity changes after ketamine in treatment resistant depression and receptor expression
+- 677: The effect of transcranial photobiomodulation on local and distal brain activity in depression
+- 1016: Mapping higher-order language regions in the cerebellum with precision functional MRI
+- 1318: Estimation of iron levels via T2* mapping increases with age in the fetal brain
+
+## WedThur posters
+- 1324: An Electrophysiology-Silent fMRI Study to Inform the Neurofunctional Basis of Startle Habituation
+- 1361: Effects of phase-encoding on BOLD data with a positive control task
+- 1568: Functional brain modularity as a metric of cognitive function in neuroPASC
+- 1572: How much is enough? Optimizing data collection for pediatric functional connectivity research
+- 1687: Evaluation of Respiratory and Cardiac Peak Detection Using Interactive AFNI Tools
+- 1777: Prenatal chronic inflammation impacts fetal brain functional
+- 1781: An fMRI study on Long-Term Brain Function in Youth with a Previous Enterovirus-71 Infection
+- 1824: Functional Network Connectivity Dynamics in the Human Fetal Brain
+- 2024: Motion regression induces global signal related bias in functional connectivity estimates
+- 2153: Simultaneous cortical, subcortical, and brainstem mapping of sensory activation
+- 2217: Multimodal precision neuroimaging of the individual human brain at ultra-high field
+- 2268: Next Move in Movement Disorders (NEMO): Imaging protocols for hyperkinetic movement disorders
+- 2278: A multimodal ultrahigh-field MRI processing pipeline
+- 2299: Transformed domain NORDIC (tNORDIC) denoising improves mesoscopic, whole brain quantitative imaging
+- 2314: Cortical folding and layering support local-to-global functional properties at 7T
+- 2408: Individualised mapping of the language system using ultra high-field fMRI
+- 2410: Longitudinal iron in caudate related to control network connectivity and planning in older adults
+- 2453: Adults born via C-section have visual attention deficits and aberrant brain network connectivity
+
+### Presentations
+Longitudinal iron in caudate related to control network connectivity and planning in older adults
+Multimodal precision neuroimaging of the individual human brain at ultra-high field
+
+Both in Neuroscience Frontiers: Exploring Cognitive Dynamics and Brain Connectivity
+Monday, June 24, 2024: 5:45 PM - 7:00 PM

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Poster WedThur 1336
 - 2453: Adults born via C-section have visual attention deficits and aberrant brain network connectivity
 
 ## Presentations
-Longitudinal iron in caudate related to control network connectivity and planning in older adults
-Multimodal precision neuroimaging of the individual human brain at ultra-high field
+- Longitudinal iron in caudate related to control network connectivity and planning in older adults
+- Multimodal precision neuroimaging of the individual human brain at ultra-high field
 
 Both in Neuroscience Frontiers: Exploring Cognitive Dynamics and Brain Connectivity
 Monday, June 24, 2024: 5:45 PM - 7:00 PM

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This is a place to centralize multi-echo related content at OHBM 2024. If you se
 
 Poster WedThur 1336
 
-### Posters with a focus on multi-echo fMRI
+## Posters with a focus on multi-echo fMRI
 ### MonTue posters
 - 1286: High field multi-echo fMRI in infants
 
-## WedThur posters
+### WedThur posters
 - 1355: Activation analysis of T2* time-series from multi-echo fMRI data
 - 1698: Hydra Nordic: A thermal-noise removal strategy for multi-echo fMRI
 - 1877: Accelerating multi-echo brain MRI at 7T using variable-density sampling & patch-based regularization
@@ -28,8 +28,8 @@ Poster WedThur 1336
 - 2325: Enhancing White Matter fMRI Reliability through BOLD-like Signals Using Multi-Echo Techniques
 - 2500: Improved performance of within- and between-individual pain prediction using multi-echo fMRI
 
-### Posters using multi-echo fMRI
-## MonTue posters
+## Posters using multi-echo fMRI
+### MonTue posters
 - 117: A comprehensive approach for TMS targeting identifies better targets than typical approaches
 - 127: TMS direct effects of orbitofrontal cortex stimulation: An interleaved TMS-fMRI study
 - 301: Essential Tremor: The Relationship Between Hand Dominance and Tremor Severity by MVPA
@@ -39,7 +39,7 @@ Poster WedThur 1336
 - 1016: Mapping higher-order language regions in the cerebellum with precision functional MRI
 - 1318: Estimation of iron levels via T2* mapping increases with age in the fetal brain
 
-## WedThur posters
+### WedThur posters
 - 1324: An Electrophysiology-Silent fMRI Study to Inform the Neurofunctional Basis of Startle Habituation
 - 1361: Effects of phase-encoding on BOLD data with a positive control task
 - 1568: Functional brain modularity as a metric of cognitive function in neuroPASC
@@ -59,7 +59,7 @@ Poster WedThur 1336
 - 2410: Longitudinal iron in caudate related to control network connectivity and planning in older adults
 - 2453: Adults born via C-section have visual attention deficits and aberrant brain network connectivity
 
-### Presentations
+## Presentations
 Longitudinal iron in caudate related to control network connectivity and planning in older adults
 Multimodal precision neuroimaging of the individual human brain at ultra-high field
 


### PR DESCRIPTION
I searched the OHBM abstracts and added the presentations and posters I found. I separated the posters into two categories: having 'multi-echo' in the title and just listing multi-echo fMRI in the methods. There were several with 'multi-echo' listed in the methods that I excluded because I wasn't sure if they fit under multi-echo fMRI, so someone can feel free to check on those (250 1566 1693 2175 2214 1982 1883 2199 2400 2306 2207 1893 217 2292 1283).

I likely missed some content, particularly presentations, so we can continue to add!